### PR TITLE
tests: include error/warning/info overview for integration test failu…

### DIFF
--- a/v2/integration/corpus_test.go
+++ b/v2/integration/corpus_test.go
@@ -158,11 +158,16 @@ func TestCorpus(t *testing.T) {
 			*configFile)
 	} else {
 		// Otherwise enforce the maps match
+		failCounter := 0
 		for k, v := range resultsByLint {
 			if conf.Expected[k] != v {
 				t.Errorf("expected lint %q to have result %s got %s\n",
 					k, conf.Expected[k], v)
+				failCounter++
 			}
+		}
+		if failCounter > 0 {
+			fmt.Printf("%d lint(s) failed", failCounter)
 		}
 	}
 


### PR DESCRIPTION
…res (#488)

This commit introduces an overview of how many lints fail when the complete
integration test is being executed. This is information can be helpful when making
a change that affected multiple lints.